### PR TITLE
Using stable/cert-manager

### DIFF
--- a/cert_manager.md
+++ b/cert_manager.md
@@ -40,8 +40,7 @@ helm repo update
 helm install \
   --name cert-manager \
   --namespace cert-manager \
-  --version v0.7.1 \
-  jetstack/cert-manager
+  stable/cert-manager
 ```
 You should see the following output:
 ```bash


### PR DESCRIPTION
Change instruction of install cert-manager to use the stable version

When I try install cert-manager on GKE I have problems with the version 0.7.1 (https://github.com/jetstack/cert-manager/issues/1475). When I change to stable version, it works fine.